### PR TITLE
PHP notice when $cpt_post_type["rewrite_withfront"] was not set

### DIFF
--- a/custom-post-type-ui.php
+++ b/custom-post-type-ui.php
@@ -97,7 +97,7 @@ function cpt_create_custom_post_types() {
             $cpt_label              = ( !empty( $cpt_post_type["label"] ) ) ? esc_html( $cpt_post_type["label"] ) : esc_html( $cpt_post_type["name"] ) ;
             $cpt_singular           = ( !empty( $cpt_post_type["singular_label"] ) ) ? esc_html( $cpt_post_type["singular_label"] ) : esc_html( $cpt_label );
             $cpt_rewrite_slug       = ( !empty( $cpt_post_type["rewrite_slug"] ) ) ? esc_html( $cpt_post_type["rewrite_slug"] ) : $cpt_post_type["name"];
-            $cpt_rewrite_withfront  = ( !empty( $cpt_post_type["rewrite_withfront"] ) ) ? true : get_disp_boolean( $cpt_post_type["rewrite_withfront"] ); //reversed because false is empty, and with_front option is true/false
+            $cpt_rewrite_withfront  = ( isset($cpt_post_type["rewrite_withfront"]) ) ? get_disp_boolean( $cpt_post_type["rewrite_withfront"] ) : true; //reversed because false is empty, and with_front option is true/false
             $cpt_menu_position      = ( !empty( $cpt_post_type["menu_position"] ) ) ? intval( $cpt_post_type["menu_position"] ) : null; //must be null
             $cpt_menu_icon          = ( !empty( $cpt_post_type["menu_icon"] ) ) ? esc_url( $cpt_post_type["menu_icon"] ) : null; //must be null
             $cpt_taxonomies         = ( !empty( $cpt_post_type[1] ) ) ? $cpt_post_type[1] : array();


### PR DESCRIPTION
Hi!
I had PHP notices in my sites (see the screenshot from a dev site) with the latest release version, that should be fixed with this minimal change :)

![image](https://f.cloud.github.com/assets/533162/1917168/fa91e102-7d8c-11e3-953e-e793a85b79f6.png)

And thanks for your Plugin!
