### PR TITLE
Change $cpt_supports value from array() to false

### DIFF
--- a/custom-post-type-ui.php
+++ b/custom-post-type-ui.php
@@ -101,7 +101,7 @@ function cpt_create_custom_post_types() {
             $cpt_menu_position      = ( !empty( $cpt_post_type["menu_position"] ) ) ? intval( $cpt_post_type["menu_position"] ) : null; //must be null
             $cpt_menu_icon          = ( !empty( $cpt_post_type["menu_icon"] ) ) ? esc_url( $cpt_post_type["menu_icon"] ) : null; //must be null
             $cpt_taxonomies         = ( !empty( $cpt_post_type[1] ) ) ? $cpt_post_type[1] : array();
-            $cpt_supports           = ( !empty( $cpt_post_type[0] ) ) ? $cpt_post_type[0] : array();
+            $cpt_supports           = ( !empty( $cpt_post_type[0] ) ) ? $cpt_post_type[0] : false;
 
 			//Show UI must be true
 			if ( true == get_disp_boolean( $cpt_post_type["show_ui"] ) ) {


### PR DESCRIPTION
In Advanced Options: Supports, when nothing is checked, the default title and editor will still show up. Set this to false to fix the issue.

From register_post_type reference: As of 3.5, boolean false can be passed as value instead of an array to prevent default (title and editor) behavior.