### PR TITLE
Add dashicon support to help title attribute.

### DIFF
--- a/custom-post-type-ui.php
+++ b/custom-post-type-ui.php
@@ -1409,7 +1409,7 @@ function cpt_add_new() {
 							</tr>
 
 							<tr valign="top">
-							<th scope="row"><?php _e('Menu Icon', 'cpt-plugin') ?> <a href="#" title="<?php esc_attr_e( 'URL to image to be used as menu icon.', 'cpt-plugin' ); ?>" class="help">?</a>
+							<th scope="row"><?php _e('Menu Icon', 'cpt-plugin') ?> <a href="#" title="<?php esc_attr_e( 'URL to image or dashicon class to be used as menu icon.', 'cpt-plugin' ); ?>" class="help">?</a>
 							</th>
 							<td><input type="text" name="cpt_custom_post_type[menu_icon]" size="20" value="<?php if (isset($cpt_menu_icon)) { echo esc_attr($cpt_menu_icon); } ?>" /> (Full URL for icon)</td>
 							</tr>


### PR DESCRIPTION
Adds a couple words to signify dashicon support within the title attribute of the help "?" in the admin area. There isn't any documentation for this except an update to the plugin that was titled "Dashicon Support." However, the lack of documentation made this difficult to understand its implementation.
