### PR TITLE
Credits strings cleanup

### DIFF
--- a/classes/class.cptui_admin_ui.php
+++ b/classes/class.cptui_admin_ui.php
@@ -240,7 +240,9 @@ class cptui_admin_ui {
 			$value .= $this->get_th_start();
 			$value .= $this->get_label( $args['name'], $args['labeltext'] );
 			if ( $args['required'] ) { $value .= $this->get_required(); }
-			$value .= $this->get_help( $args['helptext'] );
+			if ( !$args['helptext_after'] ) {
+				$value .= $this->get_help( $args['helptext'] );
+			}
 			$value .= $this->get_th_end();
 			$value .= $this->get_td_start();
 		}
@@ -255,7 +257,12 @@ class cptui_admin_ui {
 			$value .= ' ' . $this->get_onblur( $args['onblur'] );
 		}
 
-		$value .= ' /><br/>';
+		$value .= ' />';
+
+		if ( $args['helptext_after'] ) {
+			$value .= $this->get_help( $args['helptext'] );
+		}
+		$value .= '<br/>';
 
 		if ( !empty( $args['aftertext'] ) )
 			$value .= $args['aftertext'];
@@ -377,6 +384,7 @@ class cptui_admin_ui {
 				'labeltext'     => '',
 				'aftertext'     => '',
 				'helptext'      => '',
+				'helptext_after'=> false,
 				'required'      => false,
 				'wrap'          => true
 			),

--- a/custom-post-type-ui.php
+++ b/custom-post-type-ui.php
@@ -366,18 +366,23 @@ function cptui_footer( $original = '' ) {
 	}
 
 	return sprintf(
-		__( '%s version %s by %s - %s %s %s &middot; %s &middot; %s', 'cpt-plugin' ),
+		__( '%s version %s by %s', 'cpt-plugin' ),
 		sprintf(
 			'<a target="_blank" href="http://wordpress.org/support/plugin/custom-post-type-ui">%s</a>',
 			__( 'Custom Post Type UI', 'cpt-plugin' )
 		),
 		CPT_VERSION,
-		'<a href="http://webdevstudios.com" target="_blank">WebDevStudios</a>',
-		sprintf(
-			'<a href="https://github.com/WebDevStudios/custom-post-type-ui/issues" target="_blank">%s</a>',
-			__( 'Please Report Bugs', 'cpt-plugin' )
-		),
-		__( 'Follow on Twitter:', 'cpt-plugin' ),
+		'<a href="http://webdevstudios.com" target="_blank">WebDevStudios</a>'
+	).
+	' - '.
+	sprintf(
+		'<a href="https://github.com/WebDevStudios/custom-post-type-ui/issues" target="_blank">%s</a>',
+		__( 'Please Report Bugs', 'cpt-plugin' )
+	).
+	' '.
+	__( 'Follow on Twitter:', 'cpt-plugin' ).
+	sprintf(
+		' %s &middot; %s &middot; %s',
 		'<a href="http://twitter.com/tw2113" target="_blank">Michael</a>',
 		'<a href="http://twitter.com/williamsba" target="_blank">Brad</a>',
 		'<a href="http://twitter.com/webdevstudios" target="_blank">WebDevStudios</a>'

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -163,6 +163,9 @@ function cptui_manage_post_types() {
 							'helptext' => esc_attr__( 'Custom Post Type Description. Describe what your custom post type is used for.', 'cpt-plugin' )
 							) );
 
+						/*
+						 * Migrate posts
+						 */
 						if ( 'edit' == $tab ) {
 							echo $ui->get_check_input( array(
 								'checkvalue' => 'update_post_types',
@@ -378,7 +381,7 @@ function cptui_manage_post_types() {
 								'name'          => 'public',
 								'labeltext'     => __( 'Public', 'cpt-plugin' ),
 								'aftertext'     => __( '(default: True)', 'cpt-plugin' ),
-								'helptext'      => esc_attr__( 'Whether posts of this type should be shown in the admin UI', 'cpt-plugin' ),
+								'helptext'      => esc_attr__( 'Whether posts of this type should be shown in the admin UI.', 'cpt-plugin' ),
 								'selections'    => $select
 							) );
 
@@ -398,14 +401,16 @@ function cptui_manage_post_types() {
 								'name'          => 'show_ui',
 								'labeltext'     => __( 'Show UI', 'cpt-plugin' ),
 								'aftertext'     => __( '(default: True)', 'cpt-plugin' ),
-								'helptext'      => esc_attr__( 'Whether to generate a default UI for managing this post type', 'cpt-plugin' ),
+								'helptext'      => esc_attr__( 'Whether to generate a default UI for managing this post type.', 'cpt-plugin' ),
 								'selections'    => $select
 							) );
 
 							/*
 							 * Has Archive Boolean
 							 */
-							echo $ui->get_tr_start() . $ui->get_th_start() . __( 'Has Archive', 'cpt-plugin' );
+							echo $ui->get_tr_start() . $ui->get_th_start();
+							echo $ui->get_label( 'has_archive', __( 'Has Archive', 'cpt-plugin' ) );
+							echo $ui->get_help( esc_attr__( 'Whether the post type will have a post type archive page.', 'cpt-plugin' ) );
 							echo $ui->get_p( __( 'If left blank, the archive slug will default to the post type slug.', 'cpt-plugin' ) );
 							echo $ui->get_th_end() . $ui->get_td_start();
 
@@ -420,9 +425,7 @@ function cptui_manage_post_types() {
 							echo $ui->get_select_input( array(
 								'namearray'     => 'cpt_custom_post_type',
 								'name'          => 'has_archive',
-								'labeltext'     => __( 'Has Archive', 'cpt-plugin' ),
 								'aftertext'     => __( '(default: False)', 'cpt-plugin' ),
-								'helptext'      => esc_attr__( 'Whether the post type will have a post type archive page', 'cpt-plugin' ),
 								'selections'    => $select,
 								'wrap'          => false
 							) );
@@ -435,6 +438,7 @@ function cptui_manage_post_types() {
 								'name'          => 'has_archive_string',
 								'textvalue'     => ( isset( $current['has_archive_string'] ) ) ? esc_attr( $current['has_archive_string'] ) : '',
 								'helptext'      => esc_attr__( 'Slug to be used for archive page.', 'cpt-plugin' ),
+								'helptext_after'=> true,
 								'wrap'          => false
 							) );
 							echo $ui->get_td_end() . $ui->get_tr_end();
@@ -562,8 +566,11 @@ function cptui_manage_post_types() {
 								'selections'    => $select
 							) );
 
-							echo $ui->get_tr_start() . $ui->get_th_start() . __( 'Menu Position', 'cpt-plugin' );
-
+							/*
+							 * Menu Position Boolean
+							 */
+							echo $ui->get_tr_start() . $ui->get_th_start();
+							echo $ui->get_label( 'menu_position', __( 'Menu Position', 'cpt-plugin' ) );
 							echo $ui->get_help( esc_attr__( 'The position in the menu order the post type should appear. show_in_menu must be true.', 'cpt-plugin' ) );
 							echo $ui->get_p( __( 'See <a href="http://codex.wordpress.org/Function_Reference/register_post_type#Parameters">Available options</a> in the "menu_position" section. Range of 5-100', 'cpt-plugin' ) );
 
@@ -573,6 +580,7 @@ function cptui_manage_post_types() {
 								'name'          => 'menu_position',
 								'textvalue'     => ( isset( $current['menu_position'] ) ) ? esc_attr( $current['menu_position'] ) : '',
 								'helptext'      => esc_attr__( 'URL or Dashicon value for image to be used as menu icon.', 'cpt-plugin' ),
+								'helptext_after'=> true,
 								'wrap'          => false
 							) );
 							echo $ui->get_td_end() . $ui->get_tr_end();
@@ -580,7 +588,9 @@ function cptui_manage_post_types() {
 							/*
 							 * Show In Menu Boolean
 							 */
-							echo $ui->get_tr_start() . $ui->get_th_start() . __( 'Show in Menu', 'cpt-plugin' );
+							echo $ui->get_tr_start() . $ui->get_th_start();
+							echo $ui->get_label( 'show_in_menu', __( 'Show in Menu', 'cpt-plugin' ) );
+							echo $ui->get_help( esc_attr__( 'Whether to show the post type in the admin menu and where to show that menu. Note that show_ui must be true.', 'cpt-plugin' ) );
 							echo $ui->get_p( __( '"Show UI" must be "true". If an existing top level page such as "tools.php" is indicated for second input, post type will be sub menu of that.', 'cpt-plugin' ) );
 							echo $ui->get_th_end() . $ui->get_td_start();
 
@@ -595,9 +605,7 @@ function cptui_manage_post_types() {
 							echo $ui->get_select_input( array(
 								'namearray'     => 'cpt_custom_post_type',
 								'name'          => 'show_in_menu',
-								'labeltext'     => __( 'Show In Menu', 'cpt-plugin' ),
 								'aftertext'     => __( '(default: True)', 'cpt-plugin' ),
-								'helptext'      => esc_attr__( 'Whether to show the post type in the admin menu and where to show that menu. Note that show_ui must be true', 'cpt-plugin' ),
 								'selections'    => $select,
 								'wrap'          => false
 							) );
@@ -610,6 +618,7 @@ function cptui_manage_post_types() {
 								'name'          => 'show_in_menu_string',
 								'textvalue'     => ( isset( $current['show_in_menu_string'] ) ) ? esc_attr( $current['show_in_menu_string'] ) : '',
 								'helptext'      => esc_attr__( 'URL to image to be used as menu icon.', 'cpt-plugin' ),
+								'helptext_after'=> true,
 								'wrap'          => false
 							) );
 							echo $ui->get_td_end() . $ui->get_tr_end();


### PR DESCRIPTION
**Credits strings cleanup**
Separated the sentence 'Custom Post UI version by WebDevStudios' from the rest, because it isolates this single translable sentence from the rest of the line.
Pull Request made to branch 1.1.0 according to https://github.com/WebDevStudios/custom-post-type-ui/pull/247#issuecomment-76495695

**Added missing help text and `<label>` html tags in headers**
Added option *helptext_after* to allow the help text to show after the *get_text_input* function.
Added *get_label* to headers that where missing `<label>` html tags
Cleaned some `'labeltext'` and `'helptext'` properties from the settings where the text is unwrapped and placed directly in the table by *get_label()* and *get_help()* funcions, this was just to avoid redundancy
Pull Request made to branch 1.1.0 according to https://github.com/WebDevStudios/custom-post-type-ui/pull/267#issuecomment-91199248