### PR TITLE
Added missing unique identifier

### DIFF
--- a/custom-post-type-ui.php
+++ b/custom-post-type-ui.php
@@ -346,7 +346,7 @@ function cptui_settings() { ?>
 			<div class="cptui-feature feature-section col three-col">
 				<div>
 					<h4><?php _e( 'Post type migration', 'cpt-plugin' ); ?></h4>
-					<p><?php _e( 'In the past, if you changed your post type slug, you would lose immediate access to the posts in the post type and need to recover another way. We have now added support for migrating all posts within the old post type to the new post type you renamed it to.' ); ?></p>
+					<p><?php _e( 'In the past, if you changed your post type slug, you would lose immediate access to the posts in the post type and need to recover another way. We have now added support for migrating all posts within the old post type to the new post type you renamed it to.', 'cpt-plugin' ); ?></p>
 				</div>
 				<div>
 					<h4><?php _e( 'UI Refinement', 'cpt-plugin' ); ?></h4>
@@ -354,7 +354,7 @@ function cptui_settings() { ?>
 				</div>
 				<div class="last-feature">
 					<h4><?php _e( 'Registered Post Type and Taxonomy Listings', 'cpt-plugin' ); ?></h4>
-					<p><?php _e( 'We are bringing back the listing of all CPTUI-registered post types and taxonomies for easier quick view of what you have going.' ); ?></p>
+					<p><?php _e( 'We are bringing back the listing of all CPTUI-registered post types and taxonomies for easier quick view of what you have going.', 'cpt-plugin' ); ?></p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Two of the three feature strings in the about CPT UI section were missing the unique identifier and not showing the translated strings.