### PR TITLE
Updated sample text for new taxonomy to reflect WP best practices.

### DIFF
--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -106,7 +106,7 @@ function cptui_manage_taxonomies() {
 							'maxlength'     => '32',
 							'onblur'        => 'this.value=this.value.toLowerCase()',
 							'labeltext'     => __( 'Taxonomy Slug', 'cpt-plugin' ),
-							'aftertext'     => __( '(e.g. actors)', 'cpt-plugin' ),
+							'aftertext'     => __( '(e.g. actor)', 'cpt-plugin' ),
 							'helptext'      => esc_attr__( 'The taxonomy name. Used to retrieve custom taxonomy content. Should be short and unique', 'cpt-plugin'),
 							'required'      => true,
 						) );


### PR DESCRIPTION
WordPress uses "category" and "post_tag" as the slug for its default taxonomies—i.e. singular nouns. This plugin should suggest this naming convention.

(New pull request on the 1.1 branch instead of master)