### PR TITLE
Add show_in_rest arg for WP-API support

### DIFF
--- a/custom-post-type-ui.php
+++ b/custom-post-type-ui.php
@@ -212,6 +212,7 @@ function cptui_register_single_post_type( $post_type = array() ) {
 		'show_ui'             => get_disp_boolean( $post_type['show_ui'] ),
 		'has_archive'         => $has_archive,
 		'show_in_menu'        => $show_in_menu,
+		'show_in_rest'        => get_disp_boolean( $post_type['show_in_rest'] ),
 		'exclude_from_search' => $exclude_from_search,
 		'capability_type'     => $post_type['capability_type'],
 		'map_meta_cap'        => $post_type['map_meta_cap'],

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -1134,6 +1134,7 @@ function cptui_update_post_type( $data = array() ) {
 		'description'           => $description,
 		'public'                => disp_boolean( $data['cpt_custom_post_type']['public'] ),
 		'show_ui'               => disp_boolean( $data['cpt_custom_post_type']['show_ui'] ),
+		'show_in_rest'          => disp_boolean( $data['cpt_custom_post_type']['show_in_rest'] ),
 		'has_archive'           => disp_boolean( $data['cpt_custom_post_type']['has_archive'] ),
 		'has_archive_string'    => $has_archive_string,
 		'exclude_from_search'   => disp_boolean( $data['cpt_custom_post_type']['exclude_from_search'] ),

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -417,6 +417,26 @@ function cptui_manage_post_types() {
 								'helptext'      => esc_attr__( 'Whether to generate a default UI for managing this post type.', 'cpt-plugin' ),
 								'selections'    => $select
 							) );
+							
+							/*
+							 * show_in_rest Boolean
+							 */
+							$select = array(
+								'options' => array(
+									array( 'attr' => '0', 'text' => __( 'False', 'cpt-plugin' ), 'default' => 'false' ),
+									array( 'attr' => '1', 'text' => __( 'True', 'cpt-plugin' ) )
+								)
+							);
+							$selected = ( isset( $current ) ) ? disp_boolean( $current['show_in_rest'] ) : '';
+							$select['selected'] = ( !empty( $selected ) ) ? $current['show_in_rest'] : '';
+							echo $ui->get_select_input( array(
+								'namearray'     => 'cpt_custom_post_type',
+								'name'          => 'show_in_rest',
+								'labeltext'     => __( 'Show in REST API', 'cpt-plugin' ),
+								'aftertext'     => __( '(default: False)', 'cpt-plugin' ),
+								'helptext'      => esc_attr__( 'Whether to show this post type data in the WP REST API.', 'cpt-plugin' ),
+								'selections'    => $select
+							) );
 
 							/*
 							 * Has Archive Boolean


### PR DESCRIPTION
The WP-API requires the show_in_rest argument to make a CPT publicly available in the API. CPTs are hidden from the API by default in v2.

See this article for more: http://scottbolinger.com/custom-post-types-wp-api-v2/