### PR TITLE
fix menu icon size, position

### DIFF
--- a/css/cptui.css
+++ b/css/cptui.css
@@ -118,7 +118,7 @@ fieldset .cptui-help {
 	box-shadow: none;
 }
 #toplevel_page_cptui_main_menu img {
-	height: 20 px;
-	margin-top: - 2 px;
-	width: 20 px;
+	height: 20px;
+	margin-top: -2px;
+	width: 20px;
 }


### PR DESCRIPTION

<img width="133" alt="2016-01-31 0 11 45" src="https://cloud.githubusercontent.com/assets/5253290/12696526/6a309d72-c7b0-11e5-976a-6652bb726153.png">


https://wordpress.org/support/topic/huge-icon-after-update?replies=3
since 158beae70eb89de9214935e57889170597872aa6