### PR TITLE
change the value from 100% to 99%

### DIFF
--- a/css/cptui.css
+++ b/css/cptui.css
@@ -7,7 +7,7 @@
 }
 
 .posttypesui .postbox-container, .taxonomiesui .postbox-container {
-  width: 100%;
+  width: 99%; 
 }
 
 .posttypesui .postbox .toggle-indicator:before, .taxonomiesui .postbox .toggle-indicator:before {


### PR DESCRIPTION
// on my laptop and tab devices, this fixes a huge problem.  At 100%, the main container is going all the way to the bottom of the page, it appears to be a blank page until you scroll all the way to the bottom.
