### PR TITLE
Improved legibility of the "Get Code" output.

### DIFF
--- a/inc/import_export.php
+++ b/inc/import_export.php
@@ -155,17 +155,17 @@ function cptui_get_taxonomy_code( $cptui_taxonomies = array(), $single = false )
 			$callback = 'cptui_register_my_taxes_' . str_replace( '-', '_', $cptui_taxonomies[ $key ]['name'] );
 		}
 	?>
-add_action( 'init', '<?php echo $callback; ?>' );
 function <?php echo $callback; ?>() {
 <?php
 	foreach ( $cptui_taxonomies as $tax ) {
-		echo cptui_get_single_taxonomy_registery( $tax ) . "\n";
+		echo cptui_get_single_taxonomy_registery( $tax );
 	} ?>
-// End <?php echo $callback; ?>()
 }
+
+add_action( 'init', '<?php echo $callback; ?>' );
 <?php
 	} else {
-		_e( 'No taxonomies to display at this time', 'custom-post-type-ui' );
+		_e( 'No taxonomies to display at this time.', 'custom-post-type-ui' );
 	}
 }
 
@@ -228,15 +228,20 @@ function cptui_get_single_taxonomy_registery( $taxonomy = array() ) {
 	$my_theme = wp_get_theme();
 	$textdomain = $my_theme->get( 'TextDomain' );
 	?>
+
+	/**
+	 * Taxonomy: <?php echo $taxonomy['label']; ?>.
+	 */
+
 	$labels = array(
 		"name" => __( '<?php echo $taxonomy['label']; ?>', '<?php echo $textdomain; ?>' ),
 		"singular_name" => __( '<?php echo $taxonomy['singular_label']; ?>', '<?php echo $textdomain; ?>' ),
-		<?php
-		foreach ( $taxonomy['labels'] as $key => $label ) {
+<?php foreach ( $taxonomy['labels'] as $key => $label ) {
 			if ( ! empty( $label ) ) {
-				echo '"' . $key . '" => __( \'' . $label . '\', \'' . $textdomain . '\' ),' . "\n\t\t";
+				echo "\t\t" . '"' . $key . '" => __( \'' . $label . '\', \'' . $textdomain . '\' ),' . "\n";
 			}
-		} ?>);
+		} ?>
+	);
 
 	$args = array(
 		"label" => __( '<?php echo $taxonomy['label']; ?>', '<?php echo $textdomain; ?>' ),
@@ -254,6 +259,7 @@ function cptui_get_single_taxonomy_registery( $taxonomy = array() ) {
 		"rest_base" => "<?php echo $taxonomy['rest_base']; ?>",
 		"show_in_quick_edit" => <?php echo $show_in_quick_edit; ?>,
 	);
+
 	register_taxonomy( "<?php echo $taxonomy['name']; ?>", <?php echo $post_types; ?>, $args );
 <?php
 }
@@ -277,17 +283,18 @@ function cptui_get_post_type_code( $cptui_post_types = array(), $single = false 
 			$callback = 'cptui_register_my_cpts_' . str_replace( '-', '_', $cptui_post_types[ $key ]['name'] );
 		}
 	?>
-add_action( 'init', '<?php echo $callback; ?>' );
+
 function <?php echo $callback; ?>() {
 <?php // Space before this line reflects in textarea.
 	foreach ( $cptui_post_types as $type ) {
-	echo cptui_get_single_post_type_registery( $type ) . "\n";
+		echo cptui_get_single_post_type_registery( $type );
 	} ?>
-// End of <?php echo $callback; ?>()
 }
+
+add_action( 'init', '<?php echo $callback; ?>' );
 <?php
 	} else {
-		_e( 'No post types to display at this time', 'custom-post-type-ui' );
+		_e( 'No post types to display at this time.', 'custom-post-type-ui' );
 	}
 }
 
@@ -378,19 +385,25 @@ function cptui_get_single_post_type_registery( $post_type = array() ) {
 	$my_theme = wp_get_theme();
 	$textdomain = $my_theme->get( 'TextDomain' );
 	?>
+
+	/**
+	 * Post Type: <?php echo $post_type['label']; ?>.
+	 */
+
 	$labels = array(
 		"name" => __( '<?php echo $post_type['label']; ?>', '<?php echo $textdomain; ?>' ),
 		"singular_name" => __( '<?php echo $post_type['singular_label']; ?>', '<?php echo $textdomain; ?>' ),
-		<?php foreach ( $post_type['labels'] as $key => $label ) {
+<?php foreach ( $post_type['labels'] as $key => $label ) {
 			if ( ! empty( $label ) ) {
 				if ( 'parent' === $key ) {
 					// Fix for incorrect label key. See #439.
-					echo '"' . 'parent_item_colon' . '" => __( \'' . $label . '\', \'' . $textdomain . '\' ),' . "\n\t\t";
+					echo "\t\t" . '"' . 'parent_item_colon' . '" => __( \'' . $label . '\', \'' . $textdomain . '\' ),' . "\n";
 				} else {
-					echo '"' . $key . '" => __( \'' . $label . '\', \'' . $textdomain . '\' ),' . "\n\t\t";
+					echo "\t\t" . '"' . $key . '" => __( \'' . $label . '\', \'' . $textdomain . '\' ),' . "\n";
 				}
 			}
-		} ?>);
+		} ?>
+	);
 
 	$args = array(
 		"label" => __( '<?php echo $post_type['label']; ?>', '<?php echo $textdomain; ?>' ),
@@ -403,7 +416,8 @@ function cptui_get_single_post_type_registery( $post_type = array() ) {
 		"rest_base" => "<?php echo $post_type['rest_base']; ?>",
 		"has_archive" => <?php echo disp_boolean( $post_type['has_archive'] ); ?>,
 		"show_in_menu" => <?php echo disp_boolean( $post_type['show_in_menu'] ); ?>,
-		<?php if ( ! empty( $post_type['show_in_menu_string'] ) ) { ?>"show_in_menu_string" => "<?php echo $post_type['show_in_menu_string']; ?>",
+<?php if ( ! empty( $post_type['show_in_menu_string'] ) ) { ?>
+		"show_in_menu_string" => "<?php echo $post_type['show_in_menu_string']; ?>",
 <?php } ?>
 		"exclude_from_search" => <?php echo disp_boolean( $post_type['exclude_from_search'] ); ?>,
 		"capability_type" => "<?php echo $post_type['capability_type']; ?>",
@@ -411,13 +425,23 @@ function cptui_get_single_post_type_registery( $post_type = array() ) {
 		"hierarchical" => <?php echo disp_boolean( $post_type['hierarchical'] ); ?>,
 		"rewrite" => <?php echo $rewrite; ?>,
 		"query_var" => <?php echo $post_type['query_var']; ?>,
-		<?php if ( ! empty( $post_type['menu_position'] ) ) { ?>"menu_position" => <?php echo $post_type['menu_position']; ?>,<?php } ?><?php if ( ! empty( $post_type['menu_icon'] ) ) { ?>"menu_icon" => "<?php echo $post_type['menu_icon']; ?>",<?php } ?>
-<?php if ( ! empty( $supports ) ) { echo "\n\t\t" ?>"supports" => <?php echo $supports; ?>,<?php } ?>
-		<?php if ( ! empty( $taxonomies ) ) {  echo "\n\t\t" ?>"taxonomies" => <?php echo $taxonomies; ?>,
+<?php if ( ! empty( $post_type['menu_position'] ) ) { ?>
+		"menu_position" => <?php echo $post_type['menu_position']; ?>,
 <?php } ?>
-		<?php if ( true === $yarpp ) { echo "\n\t\t" ?>"yarpp_support" => <?php echo disp_boolean( $yarpp ); ?>,
+<?php if ( ! empty( $post_type['menu_icon'] ) ) { ?>
+		"menu_icon" => "<?php echo $post_type['menu_icon']; ?>",
+<?php } ?>
+<?php if ( ! empty( $supports ) ) { ?>
+		"supports" => <?php echo $supports; ?>,
+<?php } ?>
+<?php if ( ! empty( $taxonomies ) ) {  ?>
+		"taxonomies" => <?php echo $taxonomies; ?>,
+<?php } ?>
+<?php if ( true === $yarpp ) { ?>
+		"yarpp_support" => <?php echo disp_boolean( $yarpp ); ?>,
 <?php } ?>
 	);
+
 	register_post_type( "<?php echo $post_type['name']; ?>", $args );
 <?php
 }


### PR DESCRIPTION
Before example: https://gist.github.com/toscani/3ca09e9d60f93bd49672277d59a5a38c
After example: https://gist.github.com/toscani/2f8d71479a9a76def0dadf7b29ed722f