### PR TITLE
Tidy composer.json and add code standards checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,18 @@
     "forum": "https://wordpress.org/support/plugin/custom-post-type-ui",
     "docs": "http://docs.pluginize.com/"
   },
+  "config": {
+    "sort-order": true
+  },
   "minimum-stability": "dev",
   "require": {
-    "composer/installers": "~1.0",
-    "php": "^5.2|^7"
+    "php": "^5.2|^7",
+    "composer/installers": "~1.0"
   },
   "require-dev": {
-    "php" : "^5.6 || ^7.0",
-    "johnbillion/php-docs-standards": "~1.0",
+    "php": "^5.6|^7.0",
     "brain/monkey": "^2.0",
+    "johnbillion/php-docs-standards": "~1.0",
     "phpunit/phpunit": "^5.7"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,11 @@
   "require-dev": {
     "php": "^5.6|^7.0",
     "brain/monkey": "^2.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
     "johnbillion/php-docs-standards": "~1.0",
-    "phpunit/phpunit": "^5.7"
+    "phpunit/phpunit": "^5.7",
+    "sirbrillig/phpcs-variable-analysis": "^2.0",
+    "wimg/php-compatibility": "^8.0.1",
+    "wp-coding-standards/wpcs": "^0.14.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "sort-order": true
   },
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": "^5.2|^7",
     "composer/installers": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -5,16 +5,6 @@
   "type": "wordpress-plugin",
   "keywords": ["custom post types", "taxonomies", "CPT", "CMS", "post type", "custom-post-type", "taxonomy", "tax"],
   "license": "GPL-2.0+",
-  "require": {
-    "composer/installers": "~1.0",
-    "php": "^5.2|^7"
-  },
-  "require-dev": {
-    "php" : "^5.6 || ^7.0",
-    "johnbillion/php-docs-standards": "~1.0",
-    "brain/monkey": "^2.0",
-    "phpunit/phpunit": "^5.7"
-  },
   "authors": [
     {
       "name": "WebDevStudios",
@@ -27,5 +17,15 @@
     "forum": "https://wordpress.org/support/plugin/custom-post-type-ui",
     "docs": "http://docs.pluginize.com/"
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "require": {
+    "composer/installers": "~1.0",
+    "php": "^5.2|^7"
+  },
+  "require-dev": {
+    "php" : "^5.6 || ^7.0",
+    "johnbillion/php-docs-standards": "~1.0",
+    "brain/monkey": "^2.0",
+    "phpunit/phpunit": "^5.7"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
   "prefer-stable": true,
   "require": {
     "php": "^5.2|^7",
-    "composer/installers": "~1.0"
+    "composer/installers": "~1.0",
+    "roave/security-advisories": "dev-master"
   },
   "require-dev": {
     "php": "^5.6|^7.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Post Type UI">
+    <description>The code standard for Custom Post Type UI plugin.</description>
+
+    <!-- What to scan -->
+    <file>.</file>
+    <exclude-pattern>apigen/</exclude-pattern>
+    <exclude-pattern>assets/</exclude-pattern>
+    <exclude-pattern>css/</exclude-pattern>
+    <exclude-pattern>images/</exclude-pattern>
+    <exclude-pattern>js/</exclude-pattern>
+    <exclude-pattern>node_modules/</exclude-pattern>
+    <exclude-pattern>vendor/</exclude-pattern>
+
+    <!-- How to scan -->
+    <arg value="sp"/> <!-- Show sniff and progress -->
+    <arg name="colors" />
+    <arg name="extensions" value="php"/>
+    <!--<arg name="report" value="full"/>-->
+    <!--<arg name="report" value="summary"/>-->
+    <arg name="report" value="source"/>
+
+    <!-- Rules: Good use of variables -->
+    <rule ref="VariableAnalysis"/>
+
+    <!-- Rules: Check PHP version compatibility -->
+    <config name="testVersion" value="5.2-"/>
+    <rule ref="PHPCompatibility"/>
+
+    <!-- Rules: WordPress Coding Standards -->
+    <config name="minimum_supported_wp_version" value="4.6"/>
+    <rule ref="WordPress">
+        <exclude name="WordPress.VIP"/>
+    </rule>
+    <rule ref="WordPress.Files.FileName">
+        <properties>
+            <property name="strict_class_file_names" value="false"/>
+        </properties>
+        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+    </rule>
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+        <properties>
+            <property name="prefixes" type="array" value="cptui"/>
+        </properties>
+    </rule>
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array" value="custom-post-type-ui"/>
+        </properties>
+    </rule>
+    <rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
+        <properties>
+            <property name="blank_line_check" value="true"/>
+        </properties>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
I really wanted to separate these out (and can cherry pick into a new PR if needed), but one really leads on to the other.

See the individual commits for more info, but generally:

- Tidies various aspects of `composer.json`. One thing not done is the removal of `composer.lock` from the repo, since that may cause issues for someone not on the same local PHP version etc.
- Adds necessary packages for PHPCS checks, and a suggestion / first-pass at a configuration for it.

Right now, it gives 904 errors and 371 warnings in 16 files, of which 525 are automatically fixable.

Here is the breakdown of the violations:

![screenshot 2017-11-19 18 20 02](https://user-images.githubusercontent.com/88371/32993969-27658d36-cd58-11e7-9274-4c64de0d97fb.png)

Here's the breakdown of the source:

![screenshot 2017-11-19 18 18 57](https://user-images.githubusercontent.com/88371/32993972-31d4eb04-cd58-11e7-9125-d7d81124fa1a.png)


None of the violation fixes have been made, but this can be worked on over time, at which point, it can be added to `.travis-yml`, pre-commit hooks etc.

Fixes #661.