### PR TITLE
#805

### DIFF
--- a/inc/tools.php
+++ b/inc/tools.php
@@ -326,6 +326,10 @@ foreach ( $taxonomy['labels'] as $key => $label ) {
 ?>
 	];
 
+	<?php
+	$show_graphql = isset( $taxonomy['show_in_graphql'] ) ? (bool) $taxonomy['show_in_graphql'] : false;
+	?>
+
 	$args = [
 		"label" => __( "<?php echo $taxonomy['label']; ?>", "<?php echo $textdomain; ?>" ),
 		"labels" => $labels,
@@ -342,12 +346,19 @@ foreach ( $taxonomy['labels'] as $key => $label ) {
 		"rest_base" => "<?php echo $rest_base; ?>",
 		"rest_controller_class" => "<?php echo $rest_controller_class; ?>",
 		"show_in_quick_edit" => <?php echo $show_in_quick_edit; ?>,
-	<?php if ( ! empty( $meta_box_cb ) ) { ?>
-	"meta_box_cb" => <?php echo $meta_box_cb; ?>,
-	<?php } ?>
-	<?php if ( ! empty( $default_term ) ) { ?>
-	"default_term" => <?php echo $default_term; ?>,
-	<?php } ?>
+<?php if ( $show_graphql ) : ?>
+		"show_in_graphql" => <?php echo (bool) esc_html( $taxonomy['show_in_graphql'] ); ?>,
+		"graphql_single_name" => "<?php echo esc_html( $taxonomy['graphql_single_name'] ); ?>",
+		"show_in_graphql" => "<?php echo esc_html( $taxonomy['graphql_plural_name'] ); ?>",
+<?php else: ?>
+		"show_in_graphql" => 0,
+<?php endif; ?>
+<?php if ( ! empty( $meta_box_cb ) ) { ?>
+		"meta_box_cb" => <?php echo $meta_box_cb; ?>,
+<?php } ?>
+<?php if ( ! empty( $default_term ) ) { ?>
+		"default_term" => <?php echo $default_term; ?>,
+<?php } ?>
 	];
 	register_taxonomy( "<?php echo esc_html( $taxonomy['name'] ); ?>", <?php echo $post_types; ?>, $args );
 <?php
@@ -419,6 +430,9 @@ function cptui_get_single_post_type_registery( $post_type = [] ) {
 			$post_type['supports'][] = $part;
 		}
 	}
+
+
+	$show_graphql = isset( $post_type['show_in_graphql'] ) ? (bool) $post_type['show_in_graphql'] : false;
 
 	$rewrite_withfront = '';
 	$rewrite           = get_disp_boolean( $post_type['rewrite'] );
@@ -579,6 +593,13 @@ function cptui_get_single_post_type_registery( $post_type = [] ) {
 <?php if ( true === $yarpp ) { ?>
 		"yarpp_support" => <?php echo disp_boolean( $yarpp ); ?>,
 <?php } ?>
+<?php if ( $show_graphql ) : ?>
+		"show_in_graphql" => <?php echo (bool) esc_html( $post_type['show_in_graphql'] ); ?>,
+		"graphql_single_name" => "<?php echo esc_html( $post_type['graphql_single_name'] ); ?>",
+		"show_in_graphql" => "<?php echo esc_html( $post_type['graphql_plural_name'] ); ?>",
+<?php else: ?>
+		"show_in_graphql" => 0,
+<?php endif; ?>
 	];
 
 	register_post_type( "<?php echo esc_html( $post_type['name'] ); ?>", $args );


### PR DESCRIPTION
This adds support for the GraphQL fields `show_in_graphql`, `graphql_single_name` and `graphql_plural_name` to the code exporter.

Examples:

## Post Type that is not set to show in GraphQL 

When a post type or taxonomy is not set to show in graphql, or is set explicitly to `show_in_graphql => false` the output with the code exporter will be `'show_in_graphql' => 0`

![Screen Shot 2021-03-31 at 7 21 40 AM](https://user-images.githubusercontent.com/1260765/113151322-34454480-91f2-11eb-925d-34fd164d82b4.png)

## Taxonomy that _is_ set to show in GraphQL

When a post type or taxonomy is set to `"show_in_graphql" => true`,  the output with the code exporter will include the `show_in_graphql`, `graphql_single_name` and `graphql_plural_name`

![Screen Shot 2021-03-31 at 7 22 07 AM](https://user-images.githubusercontent.com/1260765/113151331-34dddb00-91f2-11eb-980e-47aea9c0293a.png)

----

Closes #805 