### PR TITLE
add nonce_field to prevent 403

### DIFF
--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -438,7 +438,7 @@ function cptui_manage_taxonomies() {
 								<input type="hidden" name="tax_original" id="tax_original" value="<?php echo esc_attr( $current['name'] ); ?>" />
 								<?php
 							}
-
+							wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce' );
 							// Used to check and see if we should prevent duplicate slugs.
 							?>
 							<input type="hidden" name="cpt_tax_status" id="cpt_tax_status" value="<?php echo esc_attr( $tab ); ?>" />


### PR DESCRIPTION
Add nonce_field to prevent 403 Forbidden error when toggling between windows on the taxonomies page.