### PR TITLE
add in "template_name" labels from WP 6.6

### DIFF
--- a/custom-post-type-ui.php
+++ b/custom-post-type-ui.php
@@ -1081,10 +1081,11 @@ function cptui_get_preserved_labels() {
 	return [
 		'post_types' => [
 			'singular' => [
-				'add_new_item' => esc_html__( 'Add new %s', 'custom-post-type-ui' ),
-				'edit_item'    => esc_html__( 'Edit %s', 'custom-post-type-ui' ),
-				'new_item'     => esc_html__( 'New %s', 'custom-post-type-ui' ),
-				'view_item'    => esc_html__( 'View %s', 'custom-post-type-ui' ),
+				'add_new_item'  => esc_html__( 'Add new %s', 'custom-post-type-ui' ),
+				'edit_item'     => esc_html__( 'Edit %s', 'custom-post-type-ui' ),
+				'new_item'      => esc_html__( 'New %s', 'custom-post-type-ui' ),
+				'view_item'     => esc_html__( 'View %s', 'custom-post-type-ui' ),
+				'template_name' => esc_html__( 'Single item: %s', 'custom-post-type-ui' ),
 			],
 			'plural'   => [
 				'view_items'         => esc_html__( 'View %s', 'custom-post-type-ui' ),
@@ -1102,6 +1103,7 @@ function cptui_get_preserved_labels() {
 				'update_item'       => esc_html__( 'Update %s', 'custom-post-type-ui' ),
 				'add_new_item'      => esc_html__( 'Add new %s', 'custom-post-type-ui' ),
 				'new_item_name'     => esc_html__( 'New %s name', 'custom-post-type-ui' ),
+				'template_name'     => esc_html__( '%s Archives', 'custom-post-type-ui' ),
 			],
 			'plural'   => [
 				'search_items'               => esc_html__( 'Search %s', 'custom-post-type-ui' ),

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -926,6 +926,23 @@ function cptui_manage_post_types() {
 									]
 								);
 
+								echo $ui->get_text_input( // phpcs:ignore.
+									[
+										'labeltext' => esc_html__( 'Template name', 'custom-post-type-ui' ),
+										'helptext'  => esc_html__( 'Use by the site editor to display on the templates/add new template screens.', 'custom-post-type-ui' ),
+										'namearray' => 'cpt_labels',
+										'name'      => 'template_name',
+										'textvalue' => isset( $current['labels']['template_name'] ) ? esc_attr( $current['labels']['template_name'] ) : '',
+										// phpcs:ignore.
+										'aftertext' => esc_html__( '(e.g. "Single item: Movie")', 'custom-post-type-ui' ),
+										'data'      => [
+											/* translators: Used for autofill */
+											'label'     => sprintf( esc_attr__( 'Single item: %s', 'custom-post-type-ui' ), 'item' ),
+											'plurality' => 'singular',
+										],
+									]
+								);
+
 								?>
 						</table>
 					</div>

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -844,6 +844,23 @@ function cptui_manage_taxonomies() {
 									],
 								]
 							);
+
+							echo $ui->get_text_input( // phpcs:ignore.
+								[
+									'namearray' => 'cpt_tax_labels',
+									'name'      => 'template_name',
+									'textvalue' => isset( $current['labels']['template_name'] ) ? esc_attr( $current['labels']['template_name'] ) : null,
+									// phpcs:ignore.
+									'aftertext' => esc_html__( '(e.g. "Category Archives")', 'custom-post-type-ui' ),
+									'labeltext' => esc_html__( 'Template name', 'custom-post-type-ui' ),
+									'helptext'  => esc_attr__( 'Use by the site editor to display on the templates/add new template screens.', 'custom-post-type-ui' ),
+									'data'      => [
+										/* translators: Used for autofill */
+										'label'     => sprintf( esc_attr__( '%s Archives', 'custom-post-type-ui' ), 'item' ),
+										'plurality' => 'singular',
+									],
+								]
+							);
 							?>
 						</table>
 					</div>


### PR DESCRIPTION
This PR adds support for specifying the "template_name" label, used in site editor.