### PR TITLE
WP track #50120: Introduce "Filter by category" as taxonomy label and "Filter by date" for post type label

### DIFF
--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -749,6 +749,22 @@ function cptui_manage_post_types() {
 
 								echo $ui->get_text_input( // phpcs:ignore.
 									[
+										'labeltext' => esc_html__( 'Filter Items By Date', 'custom-post-type-ui' ),
+										'helptext'  => esc_html__( 'Label for the date filter in list tables.', 'custom-post-type-ui' ),
+										'namearray' => 'cpt_labels',
+										'name'      => 'filter_by_date',
+										'textvalue' => isset( $current['labels']['filter_by_date'] ) ? esc_attr( $current['labels']['filter_by_date'] ) : '', // phpcs:ignore.
+										'aftertext' => esc_html__( '(e.g. Filter movies by date)', 'custom-post-type-ui' ),
+										'data'      => [
+											/* translators: Used for autofill */
+											'label'     => sprintf( esc_attr__( 'Filter %s by date', 'custom-post-type-ui' ), 'item' ),
+											'plurality' => 'plural',
+										],
+									]
+								);
+
+								echo $ui->get_text_input( // phpcs:ignore.
+									[
 										'labeltext' => esc_html__( 'Items List Navigation', 'custom-post-type-ui' ),
 										'helptext'  => esc_html__( 'Screen reader text for the pagination heading on the post type listing screen.', 'custom-post-type-ui' ),
 										'namearray' => 'cpt_labels',

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -734,6 +734,22 @@ function cptui_manage_taxonomies() {
 							echo $ui->get_text_input( // phpcs:ignore.
 								[
 									'namearray' => 'cpt_tax_labels',
+									'name'      => 'filter_by_item',
+									'textvalue' => isset( $current['labels']['filter_by_item'] ) ? esc_attr( $current['labels']['filter_by_item'] ) : null, // phpcs:ignore.
+									'aftertext' => esc_html__( '(e.g. Filter by actor)', 'custom-post-type-ui' ),
+									'labeltext' => esc_html__( 'Filter by Category', 'custom-post-type-ui' ),
+									'helptext'  => esc_attr__( 'This label is only used for hierarchical taxonomies.', 'custom-post-type-ui' ),
+									'data'      => [
+										/* translators: Used for autofill */
+										'label'     => sprintf( esc_attr__( 'Filter by %s', 'custom-post-type-ui' ), 'item' ),
+										'plurality' => 'singular',
+									],
+								]
+							);
+
+							echo $ui->get_text_input( // phpcs:ignore.
+								[
+									'namearray' => 'cpt_tax_labels',
 									'name'      => 'items_list_navigation',
 									'textvalue' => isset( $current['labels']['items_list_navigation'] ) ? esc_attr( $current['labels']['items_list_navigation'] ) : null, // phpcs:ignore.
 									'aftertext' => esc_html__( '(e.g. Actors list navigation)', 'custom-post-type-ui' ),


### PR DESCRIPTION
Added a textbox input to edit the taxonomy label `filter_by_item`

[https://core.trac.wordpress.org/changeset/50120
](https://core.trac.wordpress.org/changeset/50120
)
>Posts, Post Types: Introduce "Filter by date" and "Filter by category" as post type and taxonomy labels, respectively.

>This provides a more consistent location for these strings and allows for reusing them in other places without hardcoding them in the markup.

[https://developer.wordpress.org/reference/functions/get_taxonomy_labels/
](https://developer.wordpress.org/reference/functions/get_taxonomy_labels/
)
> filter_by_item string
This label is only used for hierarchical taxonomies. Default ‘Filter by category’, used in the posts list table.

#1004 