### PR TITLE
Feature/wdsp 2373 admin notices updates extended

### DIFF
--- a/custom-post-type-ui.php
+++ b/custom-post-type-ui.php
@@ -106,6 +106,7 @@ add_action( 'admin_init', 'cptui_make_activation_redirect', 1 );
  */
 function cptui_deactivation() {
 	flush_rewrite_rules();
+	delete_option( 'cptui-user-dismissed-extended-upsell' );
 }
 register_deactivation_hook( __FILE__, 'cptui_deactivation' );
 

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -2593,7 +2593,7 @@ add_filter( 'enter_title_here', 'cptui_custom_enter_title_here', 10, 2 );
 /**
  * Get saved description value with added nonce check for extra security.
  *
- * @since NEXT
+ * @since 1.18.2
  *
  * @return string
  */

--- a/inc/utility.php
+++ b/inc/utility.php
@@ -1073,7 +1073,7 @@ function cptui_add_dialog_delete_content_type_confirm() {
 /**
  * Output a CPTUI-Extended upsell message for use with admin notifications in "Add new ..." tab.
  *
- * @since NEXT
+ * @since 1.18.3
  *
  * @return string
  */
@@ -1089,7 +1089,7 @@ function cptui_add_new_extended_upsell_messaging() {
 /**
  * Output a CPTUI-Extended upsell message for use with admin notifications in WP_List_Table views.
  *
- * @since NEXT
+ * @since 1.18.3
  *
  * @param string $post_type_slug
  *
@@ -1112,7 +1112,7 @@ function cptui_post_type_list_extended_upsell_messaging( $post_type_slug ) {
 /**
  * Conditionally output an admin notification for our CPTUI-Extended upsell.
  *
- * @since NEXT
+ * @since 1.18.3
  */
 function cptui_extended_upsell_notification() {
 
@@ -1176,7 +1176,7 @@ add_action( 'admin_notices', 'cptui_extended_upsell_notification', 11 );
 /**
  * Mark upsell as dismissed for current user.
  *
- * @since NEXT
+ * @since 1.18.3
  */
 function cptui_handle_upsell_dismissal() {
 	if ( ! current_user_can( 'manage_options' ) ) {
@@ -1205,7 +1205,7 @@ add_action( 'admin_init', 'cptui_handle_upsell_dismissal' );
 /**
  * Clear our upsell option dismissal upon plugin upgrade.
  *
- * @since NEXT
+ * @since 1.18.3
  *
  * @param $upgrader_object
  * @param $options

--- a/inc/utility.php
+++ b/inc/utility.php
@@ -554,11 +554,6 @@ function cptui_admin_notices_helper( $message = '', $success = true, $success_ov
 	$class   = [];
 	$class[] = $success ? 'updated' : 'error';
 
-	$type = $success ? 'success' : 'error';
-	if ( ! empty( $success_override_type ) ) {
-		$type = $success_override_type;
-	}
-
 	$messagewrapstart = '<div id="message" class="' . implode( ' ', $class ) . '"><p>';
 	$messagewrapend = '</p></div>';
 
@@ -582,6 +577,11 @@ function cptui_admin_notices_helper( $message = '', $success = true, $success_ov
 		'',
 		esc_html__( 'No filter replacement. Deprecated', 'custom-post-type-ui' )
 	);
+
+	$type = $success ? 'success' : 'error';
+	if ( ! empty( $success_override_type ) ) {
+		$type = $success_override_type;
+	}
 
 	wp_admin_notice(
 		$message,

--- a/inc/utility.php
+++ b/inc/utility.php
@@ -1069,3 +1069,159 @@ function cptui_add_dialog_delete_content_type_confirm() {
 }
 #add_action( 'cptui_post_type_after_fieldsets', 'cptui_add_dialog_delete_content_type_confirm' );
 #add_action( 'cptui_taxonomy_after_fieldsets', 'cptui_add_dialog_delete_content_type_confirm' );
+
+/**
+ * Output a CPTUI-Extended upsell message for use with admin notifications in "Add new ..." tab.
+ *
+ * @since NEXT
+ *
+ * @return string
+ */
+function cptui_add_new_extended_upsell_messaging() {
+	return sprintf(
+		// translators: Placeholder will hold the name of the plugin and a link to Pluginize.
+		esc_attr__( '%1$s helps you display custom post types with blocks, shortcodes, and templates — without writing code. Explore %2$s', 'custom-post-type-ui' ),
+		'CPTUI-Extended',
+		'<a href="https://pluginize.com/plugins/custom-post-type-ui-extended/">CPTUI Extended</a>'
+	);
+}
+
+/**
+ * Output a CPTUI-Extended upsell message for use with admin notifications in WP_List_Table views.
+ *
+ * @since NEXT
+ *
+ * @param string $post_type_slug
+ *
+ * @return string;
+ */
+function cptui_post_type_list_extended_upsell_messaging( $post_type_slug ) {
+	return sprintf(
+		// translators: Placeholder will hold the name of the plugin, a link to Pluginize, and a dismiss link.
+		esc_attr__( '%1$s lets you display this post type using blocks, shortcodes, and templates — no custom code needed. Display with %2$s &mdash; %3$s', 'custom-post-type-ui' ),
+		'CPTUI-Extended',
+		'<a href="https://pluginize.com/plugins/custom-post-type-ui-extended/">CPTUI Extended</a>',
+		sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( add_query_arg( [ 'cptui-action' => 'cptui-dismiss', 'cptui-dismiss-nonce' => wp_create_nonce( 'cptui-dismiss-nonce' ) ], admin_url( 'edit.php?post_type=' . $post_type_slug ) ) ),
+			esc_html__( 'Dismiss', 'custom-post-type-ui' )
+		)
+	);
+}
+
+/**
+ * Conditionally output an admin notification for our CPTUI-Extended upsell.
+ *
+ * @since NEXT
+ */
+function cptui_extended_upsell_notification() {
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	if ( wp_doing_ajax() ) {
+		return;
+	}
+
+	// If CPTUI-Extended already exists and is active.
+	if ( class_exists( 'CPTUI_Extended' ) ) {
+		return;
+	}
+
+	$screen = get_current_screen();
+	// our Add new content type tabs.
+	if (
+		is_object( $screen ) &&
+		(
+			in_array(
+				$screen->base,
+				[ 'cpt-ui_page_cptui_manage_post_types', 'cpt-ui_page_cptui_manage_taxonomies' ],
+				true
+			) &&
+			empty( $_GET['action'] )
+		)
+	) {
+		cptui_admin_notices_helper(
+			cptui_add_new_extended_upsell_messaging(),
+			false,
+			'warning'
+		);
+	}
+
+	$public = get_post_types(
+		[
+			'_builtin' => false,
+			'public'   => true,
+		]
+	);
+
+	if ( $screen->base === 'edit' && ! empty( $_GET['post_type'] ) && in_array( $_GET['post_type'], $public, true ) ) {
+		$dismissals = get_option( 'cptui-user-dismissed-extended-upsell', [] );
+		if ( ! empty( $dismissals ) ) {
+			$user_id = get_current_user_id();
+			if ( 'true' === $dismissals[ 'user_id_' . $user_id ] ) {
+				return;
+			}
+		}
+		cptui_admin_notices_helper(
+			cptui_post_type_list_extended_upsell_messaging( sanitize_text_field( $_GET['post_type'] ) ),
+			false,
+			'warning'
+		);
+	}
+}
+add_action( 'admin_notices', 'cptui_extended_upsell_notification', 11 );
+
+/**
+ * Mark upsell as dismissed for current user.
+ *
+ * @since NEXT
+ */
+function cptui_handle_upsell_dismissal() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	if ( wp_doing_ajax() ) {
+		return;
+	}
+
+	if ( empty( $_GET['cptui-dismiss-nonce'] ) ) {
+		return;
+	}
+
+	if ( ! wp_verify_nonce( $_GET['cptui-dismiss-nonce'], 'cptui-dismiss-nonce' ) ) {
+		return;
+	}
+
+	$dismissed                          = get_option( 'cptui-user-dismissed-extended-upsell', [] );
+	$user_id                            = get_current_user_id();
+	$dismissed[ 'user_id_' . $user_id ] = 'true';
+	update_option( 'cptui-user-dismissed-extended-upsell', $dismissed );
+}
+add_action( 'admin_init', 'cptui_handle_upsell_dismissal' );
+
+/**
+ * Clear our upsell option dismissal upon plugin upgrade.
+ *
+ * @since NEXT
+ *
+ * @param $upgrader_object
+ * @param $options
+ */
+function cptui_clear_upsell_dismissed_cache( $upgrader_object, $options ) {
+	// If an update has taken place and the updated type is plugins and the plugins element exists
+	if (
+		'update' === $options['action'] &&
+		'plugin' === $options['type'] &&
+		! empty( $options['plugins'] )
+	) {
+		foreach ( $options['plugins'] as $plugin ) {
+			if ( $plugin === 'custom-post-type-ui/custom-post-type-ui.php' ) {
+				delete_option( 'cptui-user-dismissed-extended-upsell' );
+			}
+		}
+	}
+}
+add_action( 'upgrader_process_complete', 'cptui_clear_upsell_dismissed_cache', 10, 2 );

--- a/inc/utility.php
+++ b/inc/utility.php
@@ -626,7 +626,7 @@ function cptui_get_object_from_post_global() {
  * @since 1.4.0
  */
 function cptui_add_success_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		sprintf(
 			/* translators: Placeholders are just for HTML markup that doesn't need translated */
 			esc_html__( '%s has been successfully added', 'custom-post-type-ui' ),
@@ -641,7 +641,7 @@ function cptui_add_success_admin_notice() {
  * @since 1.4.0
  */
 function cptui_add_fail_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		sprintf(
 			/* translators: Placeholders are just for HTML markup that doesn't need translated */
 			esc_html__( '%s has failed to be added', 'custom-post-type-ui' ),
@@ -657,7 +657,7 @@ function cptui_add_fail_admin_notice() {
  * @since 1.4.0
  */
 function cptui_update_success_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		sprintf(
 			/* translators: Placeholders are just for HTML markup that doesn't need translated */
 			esc_html__( '%s has been successfully updated', 'custom-post-type-ui' ),
@@ -672,7 +672,7 @@ function cptui_update_success_admin_notice() {
  * @since 1.4.0
  */
 function cptui_update_fail_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		sprintf(
 			/* translators: Placeholders are just for HTML markup that doesn't need translated */
 			esc_html__( '%s has failed to be updated', 'custom-post-type-ui' ),
@@ -688,7 +688,7 @@ function cptui_update_fail_admin_notice() {
  * @since 1.4.0
  */
 function cptui_delete_success_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		sprintf(
 			/* translators: Placeholders are just for HTML markup that doesn't need translated */
 			esc_html__( '%s has been successfully deleted', 'custom-post-type-ui' ),
@@ -703,7 +703,7 @@ function cptui_delete_success_admin_notice() {
  * @since 1.4.0
  */
 function cptui_delete_fail_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		sprintf(
 			/* translators: Placeholders are just for HTML markup that doesn't need translated */
 			esc_html__( '%s has failed to be deleted', 'custom-post-type-ui' ),
@@ -719,7 +719,7 @@ function cptui_delete_fail_admin_notice() {
  * @since 1.5.0
  */
 function cptui_import_success_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		esc_html__( 'Successfully imported data.', 'custom-post-type-ui' )
 	);
 }
@@ -730,7 +730,7 @@ function cptui_import_success_admin_notice() {
  * @since 1.5.0
  */
 function cptui_import_fail_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		esc_html__( 'Invalid data provided', 'custom-post-type-ui' ),
 		false
 	);
@@ -742,7 +742,7 @@ function cptui_import_fail_admin_notice() {
  * @since 1.7.4
  */
 function cptui_nonce_fail_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		esc_html__( 'Nonce failed verification', 'custom-post-type-ui' ),
 		false
 	);
@@ -837,7 +837,7 @@ function cptui_slug_has_quotes() {
  * @since 1.4.0
  */
 function cptui_error_admin_notice() {
-	echo cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
+	cptui_admin_notices_helper( // phpcs:ignore WordPress.Security.EscapeOutput
 		apply_filters( 'cptui_custom_error_message', '' ),
 		false
 	);

--- a/inc/utility.php
+++ b/inc/utility.php
@@ -548,32 +548,49 @@ function cptui_randomize_ads( $ads = [] ) {
  *
  * @param string $message Message to use in admin notice. Optional. Default empty string.
  * @param bool   $success Whether or not a success. Optional. Default true.
- * @return mixed
  */
-function cptui_admin_notices_helper( $message = '', $success = true ) {
+function cptui_admin_notices_helper( $message = '', $success = true, $success_override_type = false ) {
 
 	$class   = [];
 	$class[] = $success ? 'updated' : 'error';
-	$class[] = 'notice is-dismissible';
+
+	$type = $success ? 'success' : 'error';
+	if ( ! empty( $success_override_type ) ) {
+		$type = $success_override_type;
+	}
 
 	$messagewrapstart = '<div id="message" class="' . implode( ' ', $class ) . '"><p>';
-
 	$messagewrapend = '</p></div>';
-
-	$action = '';
 
 	/**
 	 * Filters the custom admin notice for CPTUI.
 	 *
-	 * @since 1.0.0
+	 * @deprecated
 	 *
 	 * @param string $value            Complete HTML output for notice.
 	 * @param string $action           Action whose message is being generated.
 	 * @param string $message          The message to be displayed.
 	 * @param string $messagewrapstart Beginning wrap HTML.
 	 * @param string $messagewrapend   Ending wrap HTML.
+	 *
+	 * @since 1.0.0
 	 */
-	return apply_filters( 'cptui_admin_notice', $messagewrapstart . $message . $messagewrapend, $action, $message, $messagewrapstart, $messagewrapend );
+	$notice = apply_filters_deprecated(
+		'cptui_admin_notice',
+		[ $messagewrapstart . $message . $messagewrapend, '', $message, $messagewrapstart, $messagewrapend ],
+		'1.19.0',
+		'',
+		esc_html__( 'No filter replacement. Deprecated', 'custom-post-type-ui' )
+	);
+
+	wp_admin_notice(
+		$message,
+		[
+			'id'          => 'cptui-message',
+			'type'        => $type,
+			'dismissible' => true,
+		]
+	);
 }
 
 /**

--- a/inc/utility.php
+++ b/inc/utility.php
@@ -1082,7 +1082,7 @@ function cptui_add_new_extended_upsell_messaging() {
 		// translators: Placeholder will hold the name of the plugin and a link to Pluginize.
 		esc_attr__( '%1$s helps you display custom post types with blocks, shortcodes, and templates — without writing code. Explore %2$s', 'custom-post-type-ui' ),
 		'CPTUI-Extended',
-		'<a href="https://pluginize.com/plugins/custom-post-type-ui-extended/">CPTUI Extended</a>'
+		'<a href="https://pluginize.com/plugins/custom-post-type-ui-extended/?utm_source=cptui-admin-notice&utm_medium=plugin&utm_campaign=cptui" target="_blank">CPTUI Extended</a>'
 	);
 }
 
@@ -1100,7 +1100,7 @@ function cptui_post_type_list_extended_upsell_messaging( $post_type_slug ) {
 		// translators: Placeholder will hold the name of the plugin, a link to Pluginize, and a dismiss link.
 		esc_attr__( '%1$s lets you display this post type using blocks, shortcodes, and templates — no custom code needed. Display with %2$s &mdash; %3$s', 'custom-post-type-ui' ),
 		'CPTUI-Extended',
-		'<a href="https://pluginize.com/plugins/custom-post-type-ui-extended/">CPTUI Extended</a>',
+		'<a href="https://pluginize.com/plugins/custom-post-type-ui-extended/?utm_source=cptui-list-notice&utm_medium=plugin&utm_campaign=cptui" target="_blank">CPTUI Extended</a>',
 		sprintf(
 			'<a href="%1$s">%2$s</a>',
 			esc_url( add_query_arg( [ 'cptui-action' => 'cptui-dismiss', 'cptui-dismiss-nonce' => wp_create_nonce( 'cptui-dismiss-nonce' ) ], admin_url( 'edit.php?post_type=' . $post_type_slug ) ) ),

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "styles:compile": "sass src/scss/cptui-styles.scss build/cptui-styles.css",
     "styles:compress": "sass --style=compressed src/scss/cptui-styles.scss build/cptui-styles.min.css",
     "uglify": "uglifyjs build/cptui.js -m -c --source-map -o build/cptui.min.js && uglifyjs build/dashiconsPicker.js -m -c --source-map -o build/dashiconsPicker.min.js",
-    "create:release": "mkdirp release-build/custom-post-type-ui && cp -R build classes external images inc readme.txt LICENSE custom-post-type-ui.php wpml-config.xml release-build/custom-post-type-ui"
+    "create:release": "mkdirp release-build/custom-post-type-ui && cp -R build classes external images inc readme.txt LICENSE custom-post-type-ui.php wpml-config.xml wordfence-vendor.txt release-build/custom-post-type-ui"
   },
   "devDependencies": {
     "@wordpress/eslint-plugin": "^22.11.0",


### PR DESCRIPTION
This PR does the following:

1. Reworks how we do admin notices to make use of `wp_admin_notice()`
2. Creates two new admin notification messages for upsells for CPTUI-Extended
3. One upsell notification is for the "Add new $content_type" tab in our CPTUI settings.
4. One upsell notification is for at the top of WP List Table views for custom post types. This notification offers a "dismiss" link that updates a "dismissals" option to help determine whether or not to show the notification in the future. This option is good until deactivation or new plugin update.
5. Neither notification shows if CPTUI-Extended is already active.
6. Deletes the dismissals option upon plugin deactivation or plugin update.