### PR TITLE
Fix debug nonce verification and export textarea escaping in Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Fixed: Debug info email failing to send due to nonce field name being passed to `wp_verify_nonce()` instead of the nonce field value. Props @thisismyurl.
+* Fixed: Export textareas for post types and taxonomies outputting unescaped content; use `esc_textarea()` for correct HTML encoding. Props @thisismyurl.
 
 ## 1.17.3 - 2025-04-21
 * Fixed: PHP notices around foreach loops in cptui_post_thumbnail_theme_support().

--- a/inc/tools-sections/tools-debug.php
+++ b/inc/tools-sections/tools-debug.php
@@ -20,7 +20,7 @@ function cptui_render_debuginfo_section() {
 	wp_nonce_field( 'cptui_debuginfo_nonce_action', 'cptui_debuginfo_nonce_field' );
 
 	if ( ! empty( $_POST ) && isset( $_POST['cptui_debug_info_email'] ) && isset( $_POST['cptui_debuginfo_nonce_field'] ) ) {
-		if ( wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['cptui_debuginfo_nonce_field'] ) ), 'cptui_debuginfo_nonce_action' ) ) {
+		if ( wp_verify_nonce( wp_unslash( $_POST['cptui_debuginfo_nonce_field'] ), 'cptui_debuginfo_nonce_action' ) ) {
 			$email_args          = [];
 			$email_args['email'] = sanitize_text_field( wp_unslash( $_POST['cptui_debug_info_email'] ) );
 			$debuginfo->send_email( $email_args );

--- a/inc/tools-sections/tools-debug.php
+++ b/inc/tools-sections/tools-debug.php
@@ -20,7 +20,7 @@ function cptui_render_debuginfo_section() {
 	wp_nonce_field( 'cptui_debuginfo_nonce_action', 'cptui_debuginfo_nonce_field' );
 
 	if ( ! empty( $_POST ) && isset( $_POST['cptui_debug_info_email'] ) && isset( $_POST['cptui_debuginfo_nonce_field'] ) ) {
-		if ( wp_verify_nonce( 'cptui_debuginfo_nonce_field', 'cptui_debuginfo_nonce_action' ) ) {
+		if ( wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['cptui_debuginfo_nonce_field'] ) ), 'cptui_debuginfo_nonce_action' ) ) {
 			$email_args          = [];
 			$email_args['email'] = sanitize_text_field( wp_unslash( $_POST['cptui_debug_info_email'] ) );
 			$debuginfo->send_email( $email_args );

--- a/inc/tools.php
+++ b/inc/tools.php
@@ -419,10 +419,10 @@ function cptui_render_posttypes_taxonomies_section() {
 						}
 						$content = wp_json_encode( $cptui_post_types );
 					} else {
-						$content = esc_html__( 'No post types registered yet.', 'custom-post-type-ui' );
+						$content = __( 'No post types registered yet.', 'custom-post-type-ui' );
 					}
 					?>
-					<textarea title="<?php esc_attr_e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'custom-post-type-ui' ); ?>" onclick="this.focus();this.select();" onfocus="this.focus();this.select();" readonly="readonly" aria-readonly="true" class="cptui_post_import" id="cptui_post_export" name="cptui_post_export"><?php echo $content; // phpcs:ignore. ?></textarea>
+					<textarea title="<?php esc_attr_e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'custom-post-type-ui' ); ?>" onclick="this.focus();this.select();" onfocus="this.focus();this.select();" readonly="readonly" aria-readonly="true" class="cptui_post_import" id="cptui_post_export" name="cptui_post_export"><?php echo esc_textarea( $content ); ?></textarea>
 
 					<p>
 						<strong><?php esc_html_e( 'Use the content above to import current post types into a different WordPress site. You can also use this to simply back up your post type settings.', 'custom-post-type-ui' ); ?></strong>
@@ -463,10 +463,10 @@ function cptui_render_posttypes_taxonomies_section() {
 						}
 						$content = wp_json_encode( $cptui_taxonomies );
 					} else {
-						$content = esc_html__( 'No taxonomies registered yet.', 'custom-post-type-ui' );
+						$content = __( 'No taxonomies registered yet.', 'custom-post-type-ui' );
 					}
 					?>
-					<textarea title="<?php esc_attr_e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'custom-post-type-ui' ); ?>" onclick="this.focus();this.select()" onfocus="this.focus();this.select();" readonly="readonly" aria-readonly="true" class="cptui_tax_import" id="cptui_tax_export" name="cptui_tax_export"><?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput ?></textarea>
+					<textarea title="<?php esc_attr_e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'custom-post-type-ui' ); ?>" onclick="this.focus();this.select()" onfocus="this.focus();this.select();" readonly="readonly" aria-readonly="true" class="cptui_tax_import" id="cptui_tax_export" name="cptui_tax_export"><?php echo esc_textarea( $content ); ?></textarea>
 
 					<p>
 						<strong><?php esc_html_e( 'Use the content above to import current taxonomies into a different WordPress site. You can also use this to simply back up your taxonomy settings.', 'custom-post-type-ui' ); ?></strong>


### PR DESCRIPTION
Hi Michael,

The debug info email feature on the Tools → Debug Info screen has been silently broken: `wp_verify_nonce()` was receiving the field name (`'cptui_debuginfo_nonce_field'`) as its first argument instead of the field value from `$_POST`. The nonce check always failed, making `send_email()` unreachable and the form submission a no-op regardless of what email address was entered.

This PR also fixes the post type and taxonomy export textareas, which were using `// phpcs:ignore` to suppress the escaping warning rather than applying `esc_textarea()`. The fix removes the suppressions and adds proper output escaping; the `esc_html__()` calls on the empty-state fallback strings were also changed to `__()` so that `esc_textarea()` is the single escape point rather than layering two escape passes.

(full disclosure: AI helped me identify the issue and verify my work)